### PR TITLE
Align use case step references

### DIFF
--- a/video6/readme.md
+++ b/video6/readme.md
@@ -1,0 +1,60 @@
+# 5‑Minute Tutorial: Destructible Crate
+
+Break feedback that scales: start with a health-aware crate, layer in texture wear, deform the mesh, and finish with a loot or FX payoff. You’ll ship with a flexible config that lets designers mix and match texture swaps, mesh swaps, or both.
+
+## What you're building
+- Step 0: A crate that tracks health and reacts to hits (script.lua)
+- Step 1: Texture/SurfaceAppearance swaps driven by damage thresholds (steps/02)
+- Step 2: Mesh swaps so the silhouette dents and collapses (steps/03)
+- Step 3: Reward or effect spawn on full break (steps/04)
+- Designer toggles baked into the final script so you can choose texture, mesh, or hybrid visuals per instance
+
+## What's in here
+- [script.lua](./script.lua) — baseline health + damage handling with config flags for visuals/reward
+- [steps/](./steps) — incremental upgrades
+  - `01-damage-ready-crate.lua` — takes damage, updates health, fires events
+  - `02-add-wear-textures.lua` — adds texture/surface appearance swaps on thresholds
+  - `03-swap-damaged-meshes.lua` — swaps mesh variants alongside textures
+  - `04-reward-on-destroy.lua` — spawns loot/FX and cleans up on zero health
+- [wiki.md](./wiki.md) — Roblox services/components that power destructible props
+- [use-cases.md](./use-cases.md) — where destructible crates shine in games
+
+## Before you start
+- Place a MeshPart crate (or a Model with `PrimaryPart`) in the workspace
+- Import 2–3 texture or `SurfaceAppearance` variants (clean, cracked, broken)
+- Import 2–3 MeshPart variants that share pivot + size (pristine, dented, smashed)
+- Optional: add a `ParticleEmitter`, `Sound`, or loot Model to the crate for the reward moment
+- Decide whether crates reset (respawn/regen) or stay broken so you can wire reset logic later
+
+## Get it working (2–4 minutes)
+Step 1 — Health + damage (script.lua)
+1) Insert a Script into your crate MeshPart/Model and paste `script.lua`.
+2) Set `CONFIG.MAX_HEALTH` and `CONFIG.DAMAGE_PER_HIT` to match your weapon.
+3) Trigger `script:FindFirstChild("Damage")` (BindableEvent) or call `TakeDamage` from your weapon/projectile.
+4) Playtest and watch the Output: health prints and `CrateDamaged` events fire on hit.
+5) Confirm the crate anchors/unanchors correctly so physics stay stable when hits land.
+
+Step 2 — Texture wear (steps/02-add-wear-textures.lua)
+1) Swap in `steps/02-add-wear-textures.lua`.
+2) Populate `CONFIG.TEXTURE_STAGES` with your `SurfaceAppearance` or texture asset ids.
+3) Adjust thresholds (values between 0 and 1) so scratches and cracks appear when you expect.
+4) Playtest and confirm the crate swaps clean → cracked → broken textures as health falls.
+
+Step 3 — Mesh damage (steps/03-swap-damaged-meshes.lua)
+1) Use `steps/03-swap-damaged-meshes.lua`.
+2) Fill `CONFIG.MESH_STAGES` with mesh asset ids (same order as texture stages).
+3) Make sure each mesh keeps identical pivot/size so physics don’t pop when swapping.
+4) Playtest and check that the silhouette dents, collapses, or breaks at the right thresholds.
+
+Step 4 — Reward moment (steps/04-reward-on-destroy.lua)
+1) Use `steps/04-reward-on-destroy.lua`.
+2) Drop a loot Model or FX folder under the script and set `CONFIG.REWARD_TEMPLATE` / `CONFIG.BREAK_EFFECT`.
+3) Customize `spawnReward` to drop loot, emit particles, or both.
+4) Test a full break: reward spawns, FX play, and the crate removes itself after the delay.
+
+## Designer choice toggles
+- `USE_TEXTURE_SWAPS` — cheaper, ideal for many crates or mobile targets
+- `USE_MESH_SWAPS` — heavier but dramatic; reserve for hero props
+- `RESET_MODE` — choose between automatic regen, manual reset via event, or permanent destruction
+
+Mix and match: leave textures on for background crates, enable mesh swaps for the single hero crate in the center of your arena.

--- a/video6/script.lua
+++ b/video6/script.lua
@@ -1,0 +1,477 @@
+-- Step 00 - Damage-ready crate (baseline health + visuals config)
+-- What: Track health on a crate, react to damage, and expose events/config for later upgrades.
+-- Why: Establish a single script that designers can reuse, toggle texture/mesh swaps, and hook reward logic into.
+
+-- Services
+local Debris = game:GetService("Debris")
+local TweenService = game:GetService("TweenService")
+
+-- Root (MeshPart or Model with PrimaryPart)
+local crate = script.Parent
+assert(crate, "Script must be parented to a MeshPart or Model crate")
+
+local primary: BasePart
+if crate:IsA("Model") then
+        primary = crate.PrimaryPart or crate:FindFirstChildWhichIsA("BasePart")
+        assert(primary, "Model crate needs a PrimaryPart or BasePart child")
+else
+        assert(crate:IsA("BasePart"), "Parent must be a BasePart or Model")
+        primary = crate
+end
+
+-- Optional libraries under the script (SurfaceAppearances, MeshParts, FX)
+local libraries = {
+        surfaces = script:FindFirstChild("SurfaceAppearances"),
+        meshes   = script:FindFirstChild("Meshes"),
+        fx       = script:FindFirstChild("FX")
+}
+
+local function resolveInstance(value, ...)
+        if typeof(value) == "Instance" then
+                return value
+        elseif typeof(value) == "string" then
+                local containers = table.pack(...)
+                for i = 1, containers.n do
+                        local container = containers[i]
+                        if container then
+                                local found = container:FindFirstChild(value, true)
+                                if found then
+                                        return found
+                                end
+                        end
+                end
+        end
+        return nil
+end
+
+local CONFIG = {
+        MAX_HEALTH         = 100,
+        DAMAGE_PER_HIT     = 25,
+        DAMAGE_COOLDOWN    = 0.15, -- seconds between touch hits
+        ENABLE_TOUCH_DAMAGE = true, -- set false if you only drive damage from weapons/projectiles
+
+        USE_TEXTURE_SWAPS  = true,
+        USE_MESH_SWAPS     = false,
+
+        TEXTURE_STAGES = {
+                -- threshold is health ratio (0-1). When health/max <= threshold, apply this stage.
+                { threshold = 0.66, appearanceName = "CrateScuffed" },
+                { threshold = 0.33, appearanceName = "CrateCracked" },
+                { threshold = 0.15, appearanceName = "CrateDestroyed" },
+        },
+
+        MESH_STAGES = {
+                -- Same ordering as textures. Use meshId or meshName pointing to a child MeshPart under script.Meshes
+                { threshold = 0.66, meshName = "CrateDented" },
+                { threshold = 0.33, meshName = "CrateBroken" },
+                { threshold = 0.15, meshName = "CrateShattered" },
+        },
+
+        RESET_MODE   = "None", -- "None" (destroy), "Regen" (auto reset), "Manual" (wait for event)
+        RESET_DELAY  = 8,       -- seconds before regen when RESET_MODE == "Regen"
+
+        REWARD_TEMPLATE = nil,  -- assign e.g. script:WaitForChild("Loot")
+        REWARD_OFFSET   = Vector3.new(0, 2, 0),
+        REWARD_LIFETIME = 30,
+
+        BREAK_EFFECT    = nil,  -- assign e.g. script:WaitForChild("FX"):WaitForChild("BreakBurst")
+        EFFECT_LIFETIME = 6,
+
+        DESTROY_DELAY   = 2,    -- time after break before removing crate (if not resetting)
+        WOBBLE_TWEEN    = TweenInfo.new(0.12, Enum.EasingStyle.Quad, Enum.EasingDirection.Out, 0, true)
+}
+
+-- Preserve baseline visuals so we can restore when resetting
+local originalAppearance = nil
+local originalTextureId = nil
+local originalMaterialVariant = nil
+local originalMeshId = nil
+local originalCollisionFidelity = nil
+local originalAnchored = primary.Anchored
+local originalTransparency = primary.Transparency
+local originalCanCollide = primary.CanCollide
+
+if primary:IsA("MeshPart") then
+        originalTextureId = primary.TextureID
+        originalMeshId = primary.MeshId
+        originalMaterialVariant = primary.MaterialVariant
+        originalCollisionFidelity = primary.CollisionFidelity
+end
+
+for _, child in ipairs(primary:GetChildren()) do
+        if child:IsA("SurfaceAppearance") then
+                originalAppearance = originalAppearance or child:Clone()
+        end
+end
+
+local currentHealth = CONFIG.MAX_HEALTH
+local destroyed = false
+local lastTouchTime = 0
+
+-- Events exposed to designers (BindableEvents live under the script)
+local damageEvent = Instance.new("BindableEvent")
+damageEvent.Name = "CrateDamaged"
+damageEvent.Parent = script
+
+local destroyedEvent = Instance.new("BindableEvent")
+destroyedEvent.Name = "CrateDestroyed"
+destroyedEvent.Parent = script
+
+local resetEvent = Instance.new("BindableEvent")
+resetEvent.Name = "CrateReset"
+resetEvent.Parent = script
+
+local applyDamageEvent = Instance.new("BindableEvent")
+applyDamageEvent.Name = "Damage"
+applyDamageEvent.Parent = script
+
+local takeDamageFn = Instance.new("BindableFunction")
+takeDamageFn.Name = "TakeDamage"
+takeDamageFn.Parent = script
+
+local resetFn = Instance.new("BindableFunction")
+resetFn.Name = "Reset"
+resetFn.Parent = script
+
+-- Utility: sort stages once so threshold evaluation is predictable
+local function sortStages(stages)
+        if not stages then return end
+        table.sort(stages, function(a, b)
+                return (a.threshold or 0) < (b.threshold or 0)
+        end)
+end
+
+sortStages(CONFIG.TEXTURE_STAGES)
+sortStages(CONFIG.MESH_STAGES)
+
+local function stageForRatio(stages, ratio)
+        if not stages then return nil end
+        local chosen = nil
+        for _, stage in ipairs(stages) do
+                if ratio <= stage.threshold then
+                        chosen = stage
+                end
+        end
+        return chosen
+end
+
+local activeAppearance: SurfaceAppearance? = nil
+
+local function cloneFromLibrary(container, name, className)
+        if not container or not name then return nil end
+        local child = container:FindFirstChild(name)
+        if child and (not className or child:IsA(className)) then
+                return child:Clone()
+        end
+        return nil
+end
+
+local function clearSurfaceAppearances()
+        for _, inst in ipairs(primary:GetChildren()) do
+                if inst:IsA("SurfaceAppearance") then
+                        inst:Destroy()
+                end
+        end
+end
+
+local function applyTextureStage(stage)
+        if not CONFIG.USE_TEXTURE_SWAPS or not primary then return end
+
+        clearSurfaceAppearances()
+        activeAppearance = nil
+
+        if stage then
+                local newAppearance: SurfaceAppearance? = nil
+                if stage.appearanceName then
+                        newAppearance = cloneFromLibrary(libraries.surfaces, stage.appearanceName, "SurfaceAppearance")
+                        if not newAppearance then
+                                newAppearance = cloneFromLibrary(crate, stage.appearanceName, "SurfaceAppearance")
+                        end
+                end
+
+                if stage.appearanceId and stage.appearanceId ~= "" then
+                        newAppearance = Instance.new("SurfaceAppearance")
+                        newAppearance.ColorMap = stage.appearanceId
+                        if stage.metalnessMap then newAppearance.MetalnessMap = stage.metalnessMap end
+                        if stage.normalMap then newAppearance.NormalMap = stage.normalMap end
+                        if stage.roughnessMap then newAppearance.RoughnessMap = stage.roughnessMap end
+                end
+
+                if newAppearance then
+                        newAppearance.Name = "DamageStageAppearance"
+                        newAppearance.Parent = primary
+                        activeAppearance = newAppearance
+                end
+
+                if primary:IsA("MeshPart") then
+                        if stage.textureId then
+                                primary.TextureID = stage.textureId
+                        end
+                        if stage.materialVariant then
+                                primary.MaterialVariant = stage.materialVariant
+                        end
+                end
+        else
+                -- Restore defaults
+                if primary:IsA("MeshPart") then
+                        primary.TextureID = originalTextureId or ""
+                        primary.MaterialVariant = originalMaterialVariant or ""
+                end
+                if originalAppearance then
+                        local restored = originalAppearance:Clone()
+                        restored.Parent = primary
+                        activeAppearance = restored
+                end
+        end
+end
+
+local function applyMeshStage(stage)
+        if not CONFIG.USE_MESH_SWAPS or not primary:IsA("MeshPart") then
+                return
+        end
+
+        if stage then
+                if stage.meshId and stage.meshId ~= "" then
+                        primary.MeshId = stage.meshId
+                elseif stage.meshName then
+                        local clone = cloneFromLibrary(libraries.meshes, stage.meshName, "MeshPart")
+                        if not clone then
+                                clone = cloneFromLibrary(crate, stage.meshName, "MeshPart")
+                        end
+                        if clone then
+                                primary.MeshId = clone.MeshId
+                                primary.TextureID = clone.TextureID
+                                primary.Size = clone.Size
+                        end
+                end
+                if stage.collisionFidelity then
+                        local fidelity = stage.collisionFidelity
+                        if type(fidelity) == "string" then
+                                fidelity = Enum.CollisionFidelity[fidelity] or Enum.CollisionFidelity.Default
+                        end
+                        primary.CollisionFidelity = fidelity
+                end
+        else
+                        primary.MeshId = originalMeshId or primary.MeshId
+                        primary.TextureID = originalTextureId or primary.TextureID
+                        if originalCollisionFidelity then
+                                primary.CollisionFidelity = originalCollisionFidelity
+                        end
+        end
+end
+
+local lastStageKey = ""
+local function updateVisualState()
+        local ratio = (CONFIG.MAX_HEALTH > 0) and (currentHealth / CONFIG.MAX_HEALTH) or 0
+        local textureStage = stageForRatio(CONFIG.TEXTURE_STAGES, ratio)
+        local meshStage = stageForRatio(CONFIG.MESH_STAGES, ratio)
+
+        local stageKey = string.format("T:%s|M:%s",
+                textureStage and tostring(textureStage.threshold) or "",
+                meshStage and tostring(meshStage.threshold) or ""
+        )
+
+        if stageKey ~= lastStageKey then
+                applyTextureStage(textureStage)
+                applyMeshStage(meshStage)
+                lastStageKey = stageKey
+        end
+end
+
+local function wobble()
+        if not primary then return end
+        local goal = { Size = primary.Size * Vector3.new(1.03, 0.97, 1.03) }
+        local tween = TweenService:Create(primary, CONFIG.WOBBLE_TWEEN, goal)
+        tween:Play()
+end
+
+local function spawnReward()
+        local template = resolveInstance(CONFIG.REWARD_TEMPLATE, script, libraries.fx, crate)
+        if typeof(template) == "Instance" then
+                local reward = template:Clone()
+                local pivot = primary:GetPivot()
+                local offset = primary.CFrame:VectorToWorldSpace(CONFIG.REWARD_OFFSET)
+                local targetCFrame = pivot + offset
+
+                if reward:IsA("Model") then
+                        reward.Parent = workspace
+                        reward:PivotTo(targetCFrame)
+                elseif reward:IsA("BasePart") then
+                        reward.Parent = workspace
+                        reward.CFrame = targetCFrame
+                        reward.Anchored = false
+                else
+                        reward.Parent = primary
+                        if reward:IsA("Attachment") then
+                                reward.CFrame = targetCFrame
+                        elseif reward:IsA("ParticleEmitter") then
+                                reward.Enabled = true
+                        elseif reward:IsA("Sound") then
+                                reward:Play()
+                        end
+                end
+
+                if CONFIG.REWARD_LIFETIME and CONFIG.REWARD_LIFETIME > 0 then
+                        Debris:AddItem(reward, CONFIG.REWARD_LIFETIME)
+                end
+        end
+end
+
+local function playBreakEffect()
+        local template = resolveInstance(CONFIG.BREAK_EFFECT, libraries.fx, script, crate)
+        if typeof(template) == "Instance" then
+                local fx = template:Clone()
+                local pivot = primary:GetPivot()
+                if fx:IsA("Model") then
+                        fx.Parent = workspace
+                        fx:PivotTo(pivot)
+                else
+                        fx.Parent = primary
+                        if fx:IsA("BasePart") then
+                                fx.CFrame = pivot
+                        end
+                end
+                if CONFIG.EFFECT_LIFETIME and CONFIG.EFFECT_LIFETIME > 0 then
+                        Debris:AddItem(fx, CONFIG.EFFECT_LIFETIME)
+                end
+        end
+end
+
+local regenTask: thread? = nil
+local cleanupTask: thread? = nil
+
+local function setHealth(newHealth, source)
+        local oldHealth = currentHealth
+        currentHealth = math.clamp(newHealth, 0, CONFIG.MAX_HEALTH)
+        crate:SetAttribute("MaxHealth", CONFIG.MAX_HEALTH)
+        crate:SetAttribute("Health", currentHealth)
+
+        if currentHealth < oldHealth then
+                wobble()
+        end
+
+        updateVisualState()
+        damageEvent:Fire(crate, currentHealth, CONFIG.MAX_HEALTH, source)
+
+        if currentHealth <= 0 and not destroyed then
+                destroyed = true
+                destroyedEvent:Fire(crate, source)
+                playBreakEffect()
+                spawnReward()
+                primary.CanCollide = false
+                primary.Anchored = true
+                primary.Transparency = 1
+
+                if CONFIG.RESET_MODE == "Regen" then
+                        if regenTask then
+                                task.cancel(regenTask)
+                        end
+                        regenTask = task.delay(CONFIG.RESET_DELAY, function()
+                                regenTask = nil
+                                resetEvent:Fire(crate, "Auto")
+                                setHealth(CONFIG.MAX_HEALTH)
+                                destroyed = false
+                                primary.Anchored = originalAnchored
+                                primary.CanCollide = originalCanCollide
+                                primary.Transparency = originalTransparency
+                        end)
+                elseif CONFIG.RESET_MODE == "Manual" then
+                        -- Wait for external script to fire resetEvent or call resetFn
+                else
+                        if cleanupTask then
+                                task.cancel(cleanupTask)
+                                cleanupTask = nil
+                        end
+                        cleanupTask = task.delay(CONFIG.DESTROY_DELAY, function()
+                                if crate.Parent then
+                                        crate:Destroy()
+                                end
+                                cleanupTask = nil
+                        end)
+                end
+        elseif currentHealth > 0 then
+                destroyed = false
+                primary.Anchored = originalAnchored
+                primary.CanCollide = originalCanCollide
+                primary.Transparency = originalTransparency
+                if cleanupTask then
+                        task.cancel(cleanupTask)
+                        cleanupTask = nil
+                end
+        end
+
+        return currentHealth
+end
+
+local function applyDamage(amount, source)
+        if destroyed and CONFIG.RESET_MODE == "None" then
+                return currentHealth
+        end
+        amount = amount or CONFIG.DAMAGE_PER_HIT
+        if not amount or amount <= 0 then
+                return currentHealth
+        end
+        return setHealth(currentHealth - amount, source)
+end
+
+local function resetCrate()
+        if regenTask then
+                task.cancel(regenTask)
+                regenTask = nil
+        end
+        if cleanupTask then
+                task.cancel(cleanupTask)
+                cleanupTask = nil
+        end
+        destroyed = false
+        primary.Anchored = originalAnchored
+        primary.CanCollide = originalCanCollide
+        primary.Transparency = originalTransparency
+        setHealth(CONFIG.MAX_HEALTH)
+        if primary:IsA("MeshPart") then
+                primary.MeshId = originalMeshId or primary.MeshId
+                primary.TextureID = originalTextureId or primary.TextureID
+                primary.MaterialVariant = originalMaterialVariant or ""
+                if originalCollisionFidelity then
+                        primary.CollisionFidelity = originalCollisionFidelity
+                end
+        end
+        if CONFIG.USE_TEXTURE_SWAPS then
+                applyTextureStage(stageForRatio(CONFIG.TEXTURE_STAGES, 1))
+        end
+        resetEvent:Fire(crate, "Manual")
+end
+
+applyDamageEvent.Event:Connect(function(amount, source)
+        applyDamage(amount, source)
+end)
+
+takeDamageFn.OnInvoke = function(amount, source)
+        return applyDamage(amount, source)
+end
+
+resetFn.OnInvoke = function()
+        resetCrate()
+        return currentHealth
+end
+
+resetEvent.Event:Connect(function(_, reason)
+        if reason == "ManualSignal" then
+                resetCrate()
+        end
+end)
+
+if CONFIG.ENABLE_TOUCH_DAMAGE then
+        primary.Touched:Connect(function(hit)
+                local now = os.clock()
+                if now - lastTouchTime < CONFIG.DAMAGE_COOLDOWN then
+                        return
+                end
+                lastTouchTime = now
+                applyDamage(CONFIG.DAMAGE_PER_HIT, hit)
+        end)
+end
+
+crate:SetAttribute("MaxHealth", CONFIG.MAX_HEALTH)
+crate:SetAttribute("Health", currentHealth)
+updateVisualState()

--- a/video6/steps/01-damage-ready-crate.lua
+++ b/video6/steps/01-damage-ready-crate.lua
@@ -1,0 +1,143 @@
+-- Step 01 - Damage-ready crate
+-- What: Track health, react to hits, and expose damage/destruction events.
+-- Why: Establish a reusable destructible prop foundation before layering visuals or rewards.
+
+local TweenService = game:GetService("TweenService")
+
+local crate = script.Parent
+assert(crate, "Script must be parented to a MeshPart or Model")
+
+local primary: BasePart
+if crate:IsA("Model") then
+        primary = crate.PrimaryPart or crate:FindFirstChildWhichIsA("BasePart")
+        assert(primary, "Model crate needs a PrimaryPart or BasePart child")
+else
+        assert(crate:IsA("BasePart"), "Parent must be a BasePart or Model")
+        primary = crate
+end
+
+local CONFIG = {
+        MAX_HEALTH          = 100,
+        DAMAGE_PER_HIT      = 25,
+        DAMAGE_COOLDOWN     = 0.15, -- seconds between touch hits
+        ENABLE_TOUCH_DAMAGE = true, -- turn off when driving damage via weapons/projectiles only
+        DESTROY_ON_ZERO     = false -- set true if you want the crate removed when health hits zero
+}
+
+local originalAnchored = primary.Anchored
+local originalCanCollide = primary.CanCollide
+local originalTransparency = primary.Transparency
+
+local currentHealth = CONFIG.MAX_HEALTH
+local destroyed = false
+local lastTouchTime = 0
+
+local damageEvent = Instance.new("BindableEvent")
+damageEvent.Name = "CrateDamaged"
+damageEvent.Parent = script
+
+local destroyedEvent = Instance.new("BindableEvent")
+destroyedEvent.Name = "CrateDestroyed"
+destroyedEvent.Parent = script
+
+local applyDamageEvent = Instance.new("BindableEvent")
+applyDamageEvent.Name = "Damage"
+applyDamageEvent.Parent = script
+
+local takeDamageFn = Instance.new("BindableFunction")
+takeDamageFn.Name = "TakeDamage"
+takeDamageFn.Parent = script
+
+local resetFn = Instance.new("BindableFunction")
+resetFn.Name = "Reset"
+resetFn.Parent = script
+
+local wobbleTween = TweenInfo.new(0.12, Enum.EasingStyle.Quad, Enum.EasingDirection.Out, 0, true)
+
+local function wobble()
+        if not primary then return end
+        local goal = { Size = primary.Size * Vector3.new(1.03, 0.97, 1.03) }
+        local tween = TweenService:Create(primary, wobbleTween, goal)
+        tween:Play()
+end
+
+local function setHealth(value, source)
+        local old = currentHealth
+        currentHealth = math.clamp(value, 0, CONFIG.MAX_HEALTH)
+        crate:SetAttribute("MaxHealth", CONFIG.MAX_HEALTH)
+        crate:SetAttribute("Health", currentHealth)
+
+        if currentHealth < old then
+                wobble()
+        end
+
+        damageEvent:Fire(crate, currentHealth, CONFIG.MAX_HEALTH, source)
+        print(string.format("[Crate] Health: %d/%d", currentHealth, CONFIG.MAX_HEALTH))
+
+        if currentHealth <= 0 and not destroyed then
+                destroyed = true
+                destroyedEvent:Fire(crate, source)
+                primary.CanCollide = false
+                primary.Anchored = true
+                primary.Transparency = 0.35
+                if CONFIG.DESTROY_ON_ZERO then
+                        task.delay(1.5, function()
+                                if crate.Parent then
+                                        crate:Destroy()
+                                end
+                        end)
+                end
+        elseif currentHealth > 0 then
+                destroyed = false
+                primary.Anchored = originalAnchored
+                primary.CanCollide = originalCanCollide
+                primary.Transparency = originalTransparency
+        end
+
+        return currentHealth
+end
+
+local function applyDamage(amount, source)
+        if destroyed and CONFIG.DESTROY_ON_ZERO then
+                return currentHealth
+        end
+        amount = amount or CONFIG.DAMAGE_PER_HIT
+        if not amount or amount <= 0 then
+                return currentHealth
+        end
+        return setHealth(currentHealth - amount, source)
+end
+
+local function resetCrate()
+        destroyed = false
+        primary.Anchored = originalAnchored
+        primary.CanCollide = originalCanCollide
+        primary.Transparency = originalTransparency
+        return setHealth(CONFIG.MAX_HEALTH)
+end
+
+applyDamageEvent.Event:Connect(function(amount, source)
+        applyDamage(amount, source)
+end)
+
+takeDamageFn.OnInvoke = function(amount, source)
+        return applyDamage(amount, source)
+end
+
+resetFn.OnInvoke = function()
+        return resetCrate()
+end
+
+if CONFIG.ENABLE_TOUCH_DAMAGE then
+        primary.Touched:Connect(function(hit)
+                local now = os.clock()
+                if now - lastTouchTime < CONFIG.DAMAGE_COOLDOWN then
+                        return
+                end
+                lastTouchTime = now
+                applyDamage(CONFIG.DAMAGE_PER_HIT, hit)
+        end)
+end
+
+crate:SetAttribute("MaxHealth", CONFIG.MAX_HEALTH)
+crate:SetAttribute("Health", currentHealth)

--- a/video6/steps/02-add-wear-textures.lua
+++ b/video6/steps/02-add-wear-textures.lua
@@ -1,0 +1,270 @@
+-- Step 02 - Texture wear
+-- What: Swap textures/SurfaceAppearances as health drops using thresholds.
+-- Why: Give instant visual feedback without changing mesh or physics.
+
+-- Builds directly on Step 01. New in Step 02:
+-- * Adds optional SurfaceAppearance library support for designer-provided variants.
+-- * Introduces TEXTURE_STAGES configuration + helpers that pick textures per health threshold.
+-- * Stores the original texture/material state so reset paths return the crate to pristine visuals.
+
+local TweenService = game:GetService("TweenService")
+
+local crate = script.Parent
+assert(crate, "Script must be parented to a MeshPart or Model")
+
+local primary: BasePart
+if crate:IsA("Model") then
+        primary = crate.PrimaryPart or crate:FindFirstChildWhichIsA("BasePart")
+        assert(primary, "Model crate needs a PrimaryPart or BasePart child")
+else
+        assert(crate:IsA("BasePart"), "Parent must be a BasePart or Model")
+        primary = crate
+end
+
+local libraries = {
+        surfaces = script:FindFirstChild("SurfaceAppearances") -- Step 02 addition: folder of wear textures under the script
+}
+
+local CONFIG = {
+        MAX_HEALTH          = 100,
+        DAMAGE_PER_HIT      = 25,
+        DAMAGE_COOLDOWN     = 0.15,
+        ENABLE_TOUCH_DAMAGE = true,
+        DESTROY_ON_ZERO     = false,
+
+        -- Step 02 addition: toggle + texture stages that control cosmetic wear
+        USE_TEXTURE_SWAPS   = true,
+        TEXTURE_STAGES = {
+                { threshold = 0.66, appearanceName = "CrateScuffed" },
+                { threshold = 0.33, appearanceName = "CrateCracked" },
+                { threshold = 0.15, appearanceName = "CrateDestroyed" },
+        }
+}
+
+local originalAnchored = primary.Anchored
+local originalCanCollide = primary.CanCollide
+local originalTransparency = primary.Transparency
+
+-- Step 02 addition: preserve original surface data so reset restores the clean crate
+local originalAppearance = nil
+local originalTextureId = nil
+local originalMaterialVariant = nil
+
+if primary:IsA("MeshPart") then
+        originalTextureId = primary.TextureID
+        originalMaterialVariant = primary.MaterialVariant
+end
+
+for _, child in ipairs(primary:GetChildren()) do
+        if child:IsA("SurfaceAppearance") then
+                originalAppearance = originalAppearance or child:Clone()
+        end
+end
+
+-- Step 02 addition: helper utilities that drive texture stage selection
+local function sortStages(stages)
+        if not stages then return end
+        table.sort(stages, function(a, b)
+                return (a.threshold or 0) < (b.threshold or 0)
+        end)
+end
+
+local function stageForRatio(stages, ratio)
+        if not stages then return nil end
+        local chosen = nil
+        for _, stage in ipairs(stages) do
+                if ratio <= stage.threshold then
+                        chosen = stage
+                end
+        end
+        return chosen
+end
+
+sortStages(CONFIG.TEXTURE_STAGES)
+
+local activeAppearance: SurfaceAppearance? = nil
+
+local function cloneFromLibrary(container, name)
+        if not container or not name then return nil end
+        local child = container:FindFirstChild(name)
+        if child and child:IsA("SurfaceAppearance") then
+                return child:Clone()
+        end
+        return nil
+end
+
+local function clearSurfaceAppearances()
+        for _, inst in ipairs(primary:GetChildren()) do
+                if inst:IsA("SurfaceAppearance") then
+                        inst:Destroy()
+                end
+        end
+end
+
+local function applyTextureStage(stage)
+        if not CONFIG.USE_TEXTURE_SWAPS then return end
+
+        clearSurfaceAppearances()
+        activeAppearance = nil
+
+        if stage then
+                local appearance: SurfaceAppearance? = nil
+                if stage.appearanceName then
+                        appearance = cloneFromLibrary(libraries.surfaces, stage.appearanceName)
+                        if not appearance then
+                                appearance = cloneFromLibrary(crate, stage.appearanceName)
+                        end
+                end
+                if stage.appearanceId and stage.appearanceId ~= "" then
+                        appearance = Instance.new("SurfaceAppearance")
+                        appearance.ColorMap = stage.appearanceId
+                        if stage.normalMap then appearance.NormalMap = stage.normalMap end
+                        if stage.roughnessMap then appearance.RoughnessMap = stage.roughnessMap end
+                end
+                if appearance then
+                        appearance.Name = "DamageStageAppearance"
+                        appearance.Parent = primary
+                        activeAppearance = appearance
+                end
+                if primary:IsA("MeshPart") then
+                        if stage.textureId then
+                                primary.TextureID = stage.textureId
+                        end
+                        if stage.materialVariant then
+                                primary.MaterialVariant = stage.materialVariant
+                        end
+                end
+        else
+                if primary:IsA("MeshPart") then
+                        primary.TextureID = originalTextureId or ""
+                        primary.MaterialVariant = originalMaterialVariant or ""
+                end
+                if originalAppearance then
+                        local restored = originalAppearance:Clone()
+                        restored.Parent = primary
+                        activeAppearance = restored
+                end
+        end
+end
+
+-- Step 02 addition: main entry point that swaps SurfaceAppearances for the active damage stage
+local function updateVisuals(health)
+        local ratio = (CONFIG.MAX_HEALTH > 0) and (health / CONFIG.MAX_HEALTH) or 0
+        local stage = stageForRatio(CONFIG.TEXTURE_STAGES, ratio)
+        applyTextureStage(stage)
+end
+
+local currentHealth = CONFIG.MAX_HEALTH
+local destroyed = false
+local lastTouchTime = 0
+
+local damageEvent = Instance.new("BindableEvent")
+damageEvent.Name = "CrateDamaged"
+damageEvent.Parent = script
+
+local destroyedEvent = Instance.new("BindableEvent")
+destroyedEvent.Name = "CrateDestroyed"
+destroyedEvent.Parent = script
+
+local applyDamageEvent = Instance.new("BindableEvent")
+applyDamageEvent.Name = "Damage"
+applyDamageEvent.Parent = script
+
+local takeDamageFn = Instance.new("BindableFunction")
+takeDamageFn.Name = "TakeDamage"
+takeDamageFn.Parent = script
+
+local resetFn = Instance.new("BindableFunction")
+resetFn.Name = "Reset"
+resetFn.Parent = script
+
+local wobbleTween = TweenInfo.new(0.12, Enum.EasingStyle.Quad, Enum.EasingDirection.Out, 0, true)
+
+local function wobble()
+        if not primary then return end
+        local goal = { Size = primary.Size * Vector3.new(1.03, 0.97, 1.03) }
+        TweenService:Create(primary, wobbleTween, goal):Play()
+end
+
+local function setHealth(value, source)
+        local old = currentHealth
+        currentHealth = math.clamp(value, 0, CONFIG.MAX_HEALTH)
+        crate:SetAttribute("MaxHealth", CONFIG.MAX_HEALTH)
+        crate:SetAttribute("Health", currentHealth)
+
+        if currentHealth < old then
+                wobble()
+        end
+
+        updateVisuals(currentHealth) -- Step 02 addition: refresh cosmetic wear every time health changes
+        damageEvent:Fire(crate, currentHealth, CONFIG.MAX_HEALTH, source)
+        print(string.format("[Crate] Health: %d/%d", currentHealth, CONFIG.MAX_HEALTH))
+
+        if currentHealth <= 0 and not destroyed then
+                destroyed = true
+                destroyedEvent:Fire(crate, source)
+                primary.CanCollide = false
+                primary.Anchored = true
+                primary.Transparency = 0.35
+                if CONFIG.DESTROY_ON_ZERO then
+                        task.delay(1.5, function()
+                                if crate.Parent then
+                                        crate:Destroy()
+                                end
+                        end)
+                end
+        elseif currentHealth > 0 then
+                destroyed = false
+                primary.Anchored = originalAnchored
+                primary.CanCollide = originalCanCollide
+                primary.Transparency = originalTransparency
+        end
+
+        return currentHealth
+end
+
+local function applyDamage(amount, source)
+        if destroyed and CONFIG.DESTROY_ON_ZERO then
+                return currentHealth
+        end
+        amount = amount or CONFIG.DAMAGE_PER_HIT
+        if not amount or amount <= 0 then
+                return currentHealth
+        end
+        return setHealth(currentHealth - amount, source)
+end
+
+local function resetCrate()
+        destroyed = false
+        primary.Anchored = originalAnchored
+        primary.CanCollide = originalCanCollide
+        primary.Transparency = originalTransparency
+        return setHealth(CONFIG.MAX_HEALTH)
+end
+
+applyDamageEvent.Event:Connect(function(amount, source)
+        applyDamage(amount, source)
+end)
+
+takeDamageFn.OnInvoke = function(amount, source)
+        return applyDamage(amount, source)
+end
+
+resetFn.OnInvoke = function()
+        return resetCrate()
+end
+
+if CONFIG.ENABLE_TOUCH_DAMAGE then
+        primary.Touched:Connect(function(hit)
+                local now = os.clock()
+                if now - lastTouchTime < CONFIG.DAMAGE_COOLDOWN then
+                        return
+                end
+                lastTouchTime = now
+                applyDamage(CONFIG.DAMAGE_PER_HIT, hit)
+        end)
+end
+
+crate:SetAttribute("MaxHealth", CONFIG.MAX_HEALTH)
+crate:SetAttribute("Health", currentHealth)
+updateVisuals(currentHealth) -- Step 02 addition: ensure the correct wear stage is shown on start

--- a/video6/steps/03-swap-damaged-meshes.lua
+++ b/video6/steps/03-swap-damaged-meshes.lua
@@ -1,0 +1,337 @@
+-- Step 03 - Mesh damage
+-- What: Swap MeshPart variants alongside textures as health falls.
+-- Why: Sell damage silhouette changes for hero crates.
+
+-- Continues from Step 02. New in Step 03:
+-- * Adds a MeshPart library + MESH_STAGES config so geometry can deform with damage.
+-- * Captures original mesh + collision fidelity for proper reset behaviour.
+-- * Extends updateVisuals to apply both texture and mesh swaps in sync.
+
+local TweenService = game:GetService("TweenService")
+
+local crate = script.Parent
+assert(crate, "Script must be parented to a MeshPart or Model")
+
+local primary: BasePart
+if crate:IsA("Model") then
+        primary = crate.PrimaryPart or crate:FindFirstChildWhichIsA("BasePart")
+        assert(primary, "Model crate needs a PrimaryPart or BasePart child")
+else
+        assert(crate:IsA("BasePart"), "Parent must be a BasePart or Model")
+        primary = crate
+end
+
+local libraries = {
+        surfaces = script:FindFirstChild("SurfaceAppearances"),
+        meshes = script:FindFirstChild("Meshes") -- Step 03 addition: optional damaged MeshParts stored under the script
+}
+
+local CONFIG = {
+        MAX_HEALTH          = 100,
+        DAMAGE_PER_HIT      = 25,
+        DAMAGE_COOLDOWN     = 0.15,
+        ENABLE_TOUCH_DAMAGE = true,
+        DESTROY_ON_ZERO     = false,
+
+        USE_TEXTURE_SWAPS   = true,
+        TEXTURE_STAGES = {
+                { threshold = 0.66, appearanceName = "CrateScuffed" },
+                { threshold = 0.33, appearanceName = "CrateCracked" },
+                { threshold = 0.15, appearanceName = "CrateDestroyed" },
+        },
+
+        -- Step 03 addition: mesh swap toggle + stages for silhouette changes
+        USE_MESH_SWAPS      = true,
+        MESH_STAGES = {
+                { threshold = 0.66, meshName = "CrateDented" },
+                { threshold = 0.33, meshName = "CrateBroken" },
+                { threshold = 0.15, meshName = "CrateShattered" },
+        }
+}
+
+local originalAnchored = primary.Anchored
+local originalCanCollide = primary.CanCollide
+local originalTransparency = primary.Transparency
+
+-- Step 03 addition: remember original mesh + collision info for resets
+local originalAppearance = nil
+local originalTextureId = nil
+local originalMaterialVariant = nil
+local originalMeshId = nil
+local originalCollisionFidelity = nil
+
+if primary:IsA("MeshPart") then
+        originalTextureId = primary.TextureID
+        originalMaterialVariant = primary.MaterialVariant
+        originalMeshId = primary.MeshId
+        originalCollisionFidelity = primary.CollisionFidelity
+end
+
+for _, child in ipairs(primary:GetChildren()) do
+        if child:IsA("SurfaceAppearance") then
+                originalAppearance = originalAppearance or child:Clone()
+        end
+end
+
+local function sortStages(stages)
+        if not stages then return end
+        table.sort(stages, function(a, b)
+                return (a.threshold or 0) < (b.threshold or 0)
+        end)
+end
+
+local function stageForRatio(stages, ratio)
+        if not stages then return nil end
+        local chosen = nil
+        for _, stage in ipairs(stages) do
+                if ratio <= stage.threshold then
+                        chosen = stage
+                end
+        end
+        return chosen
+end
+
+sortStages(CONFIG.TEXTURE_STAGES)
+sortStages(CONFIG.MESH_STAGES)
+
+local activeAppearance: SurfaceAppearance? = nil
+
+local function cloneSurface(container, name)
+        if not container or not name then return nil end
+        local child = container:FindFirstChild(name)
+        if child and child:IsA("SurfaceAppearance") then
+                return child:Clone()
+        end
+        return nil
+end
+
+-- Step 03 addition: helpers for staged mesh swapping
+local function cloneMesh(container, name)
+        if not container or not name then return nil end
+        local child = container:FindFirstChild(name)
+        if child and child:IsA("MeshPart") then
+                return child:Clone()
+        end
+        return nil
+end
+
+local function clearSurfaceAppearances()
+        for _, inst in ipairs(primary:GetChildren()) do
+                if inst:IsA("SurfaceAppearance") then
+                        inst:Destroy()
+                end
+        end
+end
+
+local function applyTextureStage(stage)
+        if not CONFIG.USE_TEXTURE_SWAPS then return end
+
+        clearSurfaceAppearances()
+        activeAppearance = nil
+
+        if stage then
+                local appearance: SurfaceAppearance? = nil
+                if stage.appearanceName then
+                        appearance = cloneSurface(libraries.surfaces, stage.appearanceName)
+                        if not appearance then
+                                appearance = cloneSurface(crate, stage.appearanceName)
+                        end
+                end
+                if stage.appearanceId and stage.appearanceId ~= "" then
+                        appearance = Instance.new("SurfaceAppearance")
+                        appearance.ColorMap = stage.appearanceId
+                        if stage.normalMap then appearance.NormalMap = stage.normalMap end
+                        if stage.roughnessMap then appearance.RoughnessMap = stage.roughnessMap end
+                end
+                if appearance then
+                        appearance.Name = "DamageStageAppearance"
+                        appearance.Parent = primary
+                        activeAppearance = appearance
+                end
+                if primary:IsA("MeshPart") then
+                        if stage.textureId then
+                                primary.TextureID = stage.textureId
+                        end
+                        if stage.materialVariant then
+                                primary.MaterialVariant = stage.materialVariant
+                        end
+                end
+        else
+                if primary:IsA("MeshPart") then
+                        primary.TextureID = originalTextureId or ""
+                        primary.MaterialVariant = originalMaterialVariant or ""
+                end
+                if originalAppearance then
+                        local restored = originalAppearance:Clone()
+                        restored.Parent = primary
+                        activeAppearance = restored
+                end
+        end
+end
+
+local function applyMeshStage(stage)
+        if not CONFIG.USE_MESH_SWAPS or not primary:IsA("MeshPart") then
+                return
+        end
+
+        if stage then
+                if stage.meshId and stage.meshId ~= "" then
+                        primary.MeshId = stage.meshId
+                elseif stage.meshName then
+                        local clone = cloneMesh(libraries.meshes, stage.meshName)
+                        if not clone then
+                                clone = cloneMesh(crate, stage.meshName)
+                        end
+                        if clone then
+                                primary.MeshId = clone.MeshId
+                                primary.TextureID = clone.TextureID
+                                primary.Size = clone.Size
+                        end
+                end
+                if stage.collisionFidelity then
+                        local fidelity = stage.collisionFidelity
+                        if type(fidelity) == "string" then
+                                fidelity = Enum.CollisionFidelity[fidelity] or Enum.CollisionFidelity.Default
+                        end
+                        primary.CollisionFidelity = fidelity
+                end
+        else
+                primary.MeshId = originalMeshId or primary.MeshId
+                primary.TextureID = originalTextureId or primary.TextureID
+                if originalCollisionFidelity then
+                        primary.CollisionFidelity = originalCollisionFidelity
+                end
+        end
+end
+
+-- Step 03 addition: combine texture + mesh thresholds for cohesive feedback
+local function updateVisuals(health)
+        local ratio = (CONFIG.MAX_HEALTH > 0) and (health / CONFIG.MAX_HEALTH) or 0
+        local textureStage = stageForRatio(CONFIG.TEXTURE_STAGES, ratio)
+        local meshStage = stageForRatio(CONFIG.MESH_STAGES, ratio)
+        applyTextureStage(textureStage)
+        applyMeshStage(meshStage) -- Step 03 addition: mesh swaps accompany texture wear
+end
+
+local currentHealth = CONFIG.MAX_HEALTH
+local destroyed = false
+local lastTouchTime = 0
+
+local damageEvent = Instance.new("BindableEvent")
+damageEvent.Name = "CrateDamaged"
+damageEvent.Parent = script
+
+local destroyedEvent = Instance.new("BindableEvent")
+destroyedEvent.Name = "CrateDestroyed"
+destroyedEvent.Parent = script
+
+local applyDamageEvent = Instance.new("BindableEvent")
+applyDamageEvent.Name = "Damage"
+applyDamageEvent.Parent = script
+
+local takeDamageFn = Instance.new("BindableFunction")
+takeDamageFn.Name = "TakeDamage"
+takeDamageFn.Parent = script
+
+local resetFn = Instance.new("BindableFunction")
+resetFn.Name = "Reset"
+resetFn.Parent = script
+
+local wobbleTween = TweenInfo.new(0.12, Enum.EasingStyle.Quad, Enum.EasingDirection.Out, 0, true)
+
+local function wobble()
+        if not primary then return end
+        local goal = { Size = primary.Size * Vector3.new(1.03, 0.97, 1.03) }
+        TweenService:Create(primary, wobbleTween, goal):Play()
+end
+
+local function setHealth(value, source)
+        local old = currentHealth
+        currentHealth = math.clamp(value, 0, CONFIG.MAX_HEALTH)
+        crate:SetAttribute("MaxHealth", CONFIG.MAX_HEALTH)
+        crate:SetAttribute("Health", currentHealth)
+
+        if currentHealth < old then
+                wobble()
+        end
+
+        updateVisuals(currentHealth) -- Step 03 addition: keep texture + mesh stages aligned with health
+        damageEvent:Fire(crate, currentHealth, CONFIG.MAX_HEALTH, source)
+        print(string.format("[Crate] Health: %d/%d", currentHealth, CONFIG.MAX_HEALTH))
+
+        if currentHealth <= 0 and not destroyed then
+                destroyed = true
+                destroyedEvent:Fire(crate, source)
+                primary.CanCollide = false
+                primary.Anchored = true
+                primary.Transparency = 0.35
+                if CONFIG.DESTROY_ON_ZERO then
+                        task.delay(1.5, function()
+                                if crate.Parent then
+                                        crate:Destroy()
+                                end
+                        end)
+                end
+        elseif currentHealth > 0 then
+                destroyed = false
+                primary.Anchored = originalAnchored
+                primary.CanCollide = originalCanCollide
+                primary.Transparency = originalTransparency
+        end
+
+        return currentHealth
+end
+
+local function applyDamage(amount, source)
+        if destroyed and CONFIG.DESTROY_ON_ZERO then
+                return currentHealth
+        end
+        amount = amount or CONFIG.DAMAGE_PER_HIT
+        if not amount or amount <= 0 then
+                return currentHealth
+        end
+        return setHealth(currentHealth - amount, source)
+end
+
+local function resetCrate()
+        destroyed = false
+        primary.Anchored = originalAnchored
+        primary.CanCollide = originalCanCollide
+        primary.Transparency = originalTransparency
+        if primary:IsA("MeshPart") then
+                primary.MeshId = originalMeshId or primary.MeshId
+                primary.TextureID = originalTextureId or primary.TextureID
+                primary.MaterialVariant = originalMaterialVariant or ""
+                if originalCollisionFidelity then
+                        primary.CollisionFidelity = originalCollisionFidelity
+                end
+        end
+        return setHealth(CONFIG.MAX_HEALTH)
+end
+
+applyDamageEvent.Event:Connect(function(amount, source)
+        applyDamage(amount, source)
+end)
+
+takeDamageFn.OnInvoke = function(amount, source)
+        return applyDamage(amount, source)
+end
+
+resetFn.OnInvoke = function()
+        return resetCrate()
+end
+
+if CONFIG.ENABLE_TOUCH_DAMAGE then
+        primary.Touched:Connect(function(hit)
+                local now = os.clock()
+                if now - lastTouchTime < CONFIG.DAMAGE_COOLDOWN then
+                        return
+                end
+                lastTouchTime = now
+                applyDamage(CONFIG.DAMAGE_PER_HIT, hit)
+        end)
+end
+
+crate:SetAttribute("MaxHealth", CONFIG.MAX_HEALTH)
+crate:SetAttribute("Health", currentHealth)
+updateVisuals(currentHealth) -- Step 03 addition: initialise both texture and mesh visuals

--- a/video6/steps/04-reward-on-destroy.lua
+++ b/video6/steps/04-reward-on-destroy.lua
@@ -1,0 +1,471 @@
+-- Step 04 - Reward + cleanup
+-- What: Spawn loot or FX when the crate breaks and optionally reset it after a delay.
+-- Why: Finish the loop so destruction feels rewarding and reusable.
+
+-- Extends Step 03. New in Step 04:
+-- * Adds helpers/config to resolve FX or loot templates referenced by name.
+-- * Spawns optional rewards + break FX, with Debris cleanup for temporary instances.
+-- * Introduces reset behaviour toggles so crates can respawn or stay destroyed.
+
+local Debris = game:GetService("Debris")
+local TweenService = game:GetService("TweenService")
+
+local crate = script.Parent
+assert(crate, "Script must be parented to a MeshPart or Model")
+
+local primary: BasePart
+if crate:IsA("Model") then
+        primary = crate.PrimaryPart or crate:FindFirstChildWhichIsA("BasePart")
+        assert(primary, "Model crate needs a PrimaryPart or BasePart child")
+else
+        assert(crate:IsA("BasePart"), "Parent must be a BasePart or Model")
+        primary = crate
+end
+
+local libraries = {
+        surfaces = script:FindFirstChild("SurfaceAppearances"),
+        meshes = script:FindFirstChild("Meshes"),
+        fx = script:FindFirstChild("FX") -- Step 04 addition: store loot/effect templates beside the script
+}
+
+-- Step 04 addition: helper resolves string config into concrete Instances from provided containers
+local function resolveInstance(value, ...)
+        if typeof(value) == "Instance" then
+                return value
+        elseif typeof(value) == "string" then
+                local containers = table.pack(...)
+                for i = 1, containers.n do
+                        local container = containers[i]
+                        if container then
+                                local found = container:FindFirstChild(value, true)
+                                if found then
+                                        return found
+                                end
+                        end
+                end
+        end
+        return nil
+end
+
+local CONFIG = {
+        MAX_HEALTH          = 100,
+        DAMAGE_PER_HIT      = 25,
+        DAMAGE_COOLDOWN     = 0.15,
+        ENABLE_TOUCH_DAMAGE = true,
+
+        USE_TEXTURE_SWAPS   = true,
+        TEXTURE_STAGES = {
+                { threshold = 0.66, appearanceName = "CrateScuffed" },
+                { threshold = 0.33, appearanceName = "CrateCracked" },
+                { threshold = 0.15, appearanceName = "CrateDestroyed" },
+        },
+
+        USE_MESH_SWAPS      = true,
+        MESH_STAGES = {
+                { threshold = 0.66, meshName = "CrateDented" },
+                { threshold = 0.33, meshName = "CrateBroken" },
+                { threshold = 0.15, meshName = "CrateShattered" },
+        },
+
+        -- Step 04 addition: reward + reset knobs for the final polish pass
+        RESET_MODE   = "None", -- "None" destroys, "Regen" auto resets after delay
+        RESET_DELAY  = 8,
+
+        REWARD_TEMPLATE = nil,  -- assign script:WaitForChild("Loot") or similar
+        REWARD_OFFSET   = Vector3.new(0, 2, 0),
+        REWARD_LIFETIME = 30,
+
+        BREAK_EFFECT    = nil,  -- assign script.FX.BreakBurst, ParticleEmitter, etc.
+        EFFECT_LIFETIME = 6,
+
+        DESTROY_DELAY   = 2,
+        WOBBLE_TWEEN    = TweenInfo.new(0.12, Enum.EasingStyle.Quad, Enum.EasingDirection.Out, 0, true)
+}
+
+local originalAnchored = primary.Anchored
+local originalCanCollide = primary.CanCollide
+local originalTransparency = primary.Transparency
+
+local originalAppearance = nil
+local originalTextureId = nil
+local originalMaterialVariant = nil
+local originalMeshId = nil
+local originalCollisionFidelity = nil
+
+if primary:IsA("MeshPart") then
+        originalTextureId = primary.TextureID
+        originalMaterialVariant = primary.MaterialVariant
+        originalMeshId = primary.MeshId
+        originalCollisionFidelity = primary.CollisionFidelity
+end
+
+for _, child in ipairs(primary:GetChildren()) do
+        if child:IsA("SurfaceAppearance") then
+                originalAppearance = originalAppearance or child:Clone()
+        end
+end
+
+local function sortStages(stages)
+        if not stages then return end
+        table.sort(stages, function(a, b)
+                return (a.threshold or 0) < (b.threshold or 0)
+        end)
+end
+
+local function stageForRatio(stages, ratio)
+        if not stages then return nil end
+        local chosen = nil
+        for _, stage in ipairs(stages) do
+                if ratio <= stage.threshold then
+                        chosen = stage
+                end
+        end
+        return chosen
+end
+
+sortStages(CONFIG.TEXTURE_STAGES)
+sortStages(CONFIG.MESH_STAGES)
+
+local activeAppearance: SurfaceAppearance? = nil
+
+local function cloneSurface(container, name)
+        if not container or not name then return nil end
+        local child = container:FindFirstChild(name)
+        if child and child:IsA("SurfaceAppearance") then
+                return child:Clone()
+        end
+        return nil
+end
+
+local function cloneMesh(container, name)
+        if not container or not name then return nil end
+        local child = container:FindFirstChild(name)
+        if child and child:IsA("MeshPart") then
+                return child:Clone()
+        end
+        return nil
+end
+
+local function clearSurfaceAppearances()
+        for _, inst in ipairs(primary:GetChildren()) do
+                if inst:IsA("SurfaceAppearance") then
+                        inst:Destroy()
+                end
+        end
+end
+
+local function applyTextureStage(stage)
+        if not CONFIG.USE_TEXTURE_SWAPS then return end
+
+        clearSurfaceAppearances()
+        activeAppearance = nil
+
+        if stage then
+                local appearance: SurfaceAppearance? = nil
+                if stage.appearanceName then
+                        appearance = cloneSurface(libraries.surfaces, stage.appearanceName)
+                        if not appearance then
+                                appearance = cloneSurface(crate, stage.appearanceName)
+                        end
+                end
+                if stage.appearanceId and stage.appearanceId ~= "" then
+                        appearance = Instance.new("SurfaceAppearance")
+                        appearance.ColorMap = stage.appearanceId
+                        if stage.normalMap then appearance.NormalMap = stage.normalMap end
+                        if stage.roughnessMap then appearance.RoughnessMap = stage.roughnessMap end
+                end
+                if appearance then
+                        appearance.Name = "DamageStageAppearance"
+                        appearance.Parent = primary
+                        activeAppearance = appearance
+                end
+                if primary:IsA("MeshPart") then
+                        if stage.textureId then
+                                primary.TextureID = stage.textureId
+                        end
+                        if stage.materialVariant then
+                                primary.MaterialVariant = stage.materialVariant
+                        end
+                end
+        else
+                if primary:IsA("MeshPart") then
+                        primary.TextureID = originalTextureId or ""
+                        primary.MaterialVariant = originalMaterialVariant or ""
+                end
+                if originalAppearance then
+                        local restored = originalAppearance:Clone()
+                        restored.Parent = primary
+                        activeAppearance = restored
+                end
+        end
+end
+
+local function applyMeshStage(stage)
+        if not CONFIG.USE_MESH_SWAPS or not primary:IsA("MeshPart") then
+                return
+        end
+
+        if stage then
+                if stage.meshId and stage.meshId ~= "" then
+                        primary.MeshId = stage.meshId
+                elseif stage.meshName then
+                        local clone = cloneMesh(libraries.meshes, stage.meshName)
+                        if not clone then
+                                clone = cloneMesh(crate, stage.meshName)
+                        end
+                        if clone then
+                                primary.MeshId = clone.MeshId
+                                primary.TextureID = clone.TextureID
+                                primary.Size = clone.Size
+                        end
+                end
+                if stage.collisionFidelity then
+                        local fidelity = stage.collisionFidelity
+                        if type(fidelity) == "string" then
+                                fidelity = Enum.CollisionFidelity[fidelity] or Enum.CollisionFidelity.Default
+                        end
+                        primary.CollisionFidelity = fidelity
+                end
+        else
+                primary.MeshId = originalMeshId or primary.MeshId
+                primary.TextureID = originalTextureId or primary.TextureID
+                if originalCollisionFidelity then
+                        primary.CollisionFidelity = originalCollisionFidelity
+                end
+        end
+end
+
+-- Step 04 carries forward Step 03 visuals management
+local function updateVisuals(health)
+        local ratio = (CONFIG.MAX_HEALTH > 0) and (health / CONFIG.MAX_HEALTH) or 0
+        local textureStage = stageForRatio(CONFIG.TEXTURE_STAGES, ratio)
+        local meshStage = stageForRatio(CONFIG.MESH_STAGES, ratio)
+        applyTextureStage(textureStage)
+        applyMeshStage(meshStage)
+end
+
+-- Step 04 addition: spawn loot/collectibles when the crate breaks
+local function spawnReward()
+        local template = resolveInstance(CONFIG.REWARD_TEMPLATE, script, libraries.fx, crate)
+        if typeof(template) == "Instance" then
+                local reward = template:Clone()
+                local pivot = primary:GetPivot()
+                local offset = primary.CFrame:VectorToWorldSpace(CONFIG.REWARD_OFFSET)
+                local targetCFrame = pivot + offset
+
+                if reward:IsA("Model") then
+                        reward.Parent = workspace
+                        reward:PivotTo(targetCFrame)
+                elseif reward:IsA("BasePart") then
+                        reward.Parent = workspace
+                        reward.CFrame = targetCFrame
+                        reward.Anchored = false
+                else
+                        reward.Parent = primary
+                        if reward:IsA("Attachment") then
+                                reward.CFrame = targetCFrame
+                        elseif reward:IsA("ParticleEmitter") then
+                                reward.Enabled = true
+                        elseif reward:IsA("Sound") then
+                                reward:Play()
+                        end
+                end
+
+                if CONFIG.REWARD_LIFETIME and CONFIG.REWARD_LIFETIME > 0 then
+                        Debris:AddItem(reward, CONFIG.REWARD_LIFETIME)
+                end
+        end
+end
+
+-- Step 04 addition: optional particles/sound when the crate breaks
+local function playBreakEffect()
+        local template = resolveInstance(CONFIG.BREAK_EFFECT, libraries.fx, script, crate)
+        if typeof(template) == "Instance" then
+                local fx = template:Clone()
+                local pivot = primary:GetPivot()
+                if fx:IsA("Model") then
+                        fx.Parent = workspace
+                        fx:PivotTo(pivot)
+                else
+                        fx.Parent = primary
+                        if fx:IsA("BasePart") then
+                                fx.CFrame = pivot
+                        elseif fx:IsA("ParticleEmitter") then
+                                fx.Enabled = true
+                        elseif fx:IsA("Sound") then
+                                fx:Play()
+                        end
+                end
+                if CONFIG.EFFECT_LIFETIME and CONFIG.EFFECT_LIFETIME > 0 then
+                        Debris:AddItem(fx, CONFIG.EFFECT_LIFETIME)
+                end
+        end
+end
+
+local currentHealth = CONFIG.MAX_HEALTH
+local destroyed = false
+local lastTouchTime = 0
+local regenTask: thread? = nil
+local cleanupTask: thread? = nil
+
+local damageEvent = Instance.new("BindableEvent")
+damageEvent.Name = "CrateDamaged"
+damageEvent.Parent = script
+
+local destroyedEvent = Instance.new("BindableEvent")
+destroyedEvent.Name = "CrateDestroyed"
+destroyedEvent.Parent = script
+
+-- Step 04 addition: designers can listen for when the crate comes back
+local resetEvent = Instance.new("BindableEvent")
+resetEvent.Name = "CrateReset"
+resetEvent.Parent = script
+
+local applyDamageEvent = Instance.new("BindableEvent")
+applyDamageEvent.Name = "Damage"
+applyDamageEvent.Parent = script
+
+local takeDamageFn = Instance.new("BindableFunction")
+takeDamageFn.Name = "TakeDamage"
+takeDamageFn.Parent = script
+
+local resetFn = Instance.new("BindableFunction")
+resetFn.Name = "Reset"
+resetFn.Parent = script
+
+local wobbleTween = CONFIG.WOBBLE_TWEEN
+
+local function wobble()
+        if not primary then return end
+        local goal = { Size = primary.Size * Vector3.new(1.03, 0.97, 1.03) }
+        TweenService:Create(primary, wobbleTween, goal):Play()
+end
+
+local function setHealth(value, source)
+        local old = currentHealth
+        currentHealth = math.clamp(value, 0, CONFIG.MAX_HEALTH)
+        crate:SetAttribute("MaxHealth", CONFIG.MAX_HEALTH)
+        crate:SetAttribute("Health", currentHealth)
+
+        if currentHealth < old then
+                wobble()
+        end
+
+        updateVisuals(currentHealth) -- Step 04 addition: drive visuals before reward/effect logic
+        damageEvent:Fire(crate, currentHealth, CONFIG.MAX_HEALTH, source)
+        print(string.format("[Crate] Health: %d/%d", currentHealth, CONFIG.MAX_HEALTH))
+
+        if currentHealth <= 0 and not destroyed then
+                destroyed = true
+                destroyedEvent:Fire(crate, source)
+                playBreakEffect() -- Step 04 addition: trigger optional break FX
+                spawnReward()     -- Step 04 addition: drop loot or other reward prefabs
+                primary.CanCollide = false
+                primary.Anchored = true
+                primary.Transparency = 1
+
+                if CONFIG.RESET_MODE == "Regen" then -- Step 04 addition: regen flow restores crate automatically
+                        if regenTask then
+                                task.cancel(regenTask)
+                        end
+                        regenTask = task.delay(CONFIG.RESET_DELAY, function()
+                                regenTask = nil
+                                destroyed = false
+                                primary.Anchored = originalAnchored
+                                primary.CanCollide = originalCanCollide
+                                primary.Transparency = originalTransparency
+                                setHealth(CONFIG.MAX_HEALTH)
+                        end)
+                else -- Step 04 addition: destroy or clean up without auto-regen
+                        if cleanupTask then
+                                task.cancel(cleanupTask)
+                                cleanupTask = nil
+                        end
+                        cleanupTask = task.delay(CONFIG.DESTROY_DELAY, function()
+                                if crate.Parent and CONFIG.RESET_MODE == "None" then
+                                        crate:Destroy()
+                                end
+                                cleanupTask = nil
+                        end)
+                end
+        elseif currentHealth > 0 then
+                destroyed = false
+                primary.Anchored = originalAnchored
+                primary.CanCollide = originalCanCollide
+                primary.Transparency = originalTransparency
+                if cleanupTask then
+                        task.cancel(cleanupTask)
+                        cleanupTask = nil
+                end
+        end
+
+        return currentHealth
+end
+
+local function applyDamage(amount, source)
+        if destroyed and CONFIG.RESET_MODE == "None" then
+                return currentHealth
+        end
+        amount = amount or CONFIG.DAMAGE_PER_HIT
+        if not amount or amount <= 0 then
+                return currentHealth
+        end
+        return setHealth(currentHealth - amount, source)
+end
+
+local function resetCrate()
+        if regenTask then
+                task.cancel(regenTask)
+                regenTask = nil
+        end
+        if cleanupTask then
+                task.cancel(cleanupTask)
+                cleanupTask = nil
+        end
+        destroyed = false
+        primary.Anchored = originalAnchored
+        primary.CanCollide = originalCanCollide
+        primary.Transparency = originalTransparency
+        if primary:IsA("MeshPart") then
+                primary.MeshId = originalMeshId or primary.MeshId
+                primary.TextureID = originalTextureId or primary.TextureID
+                primary.MaterialVariant = originalMaterialVariant or ""
+                if originalCollisionFidelity then
+                        primary.CollisionFidelity = originalCollisionFidelity
+                end
+        end
+        setHealth(CONFIG.MAX_HEALTH)
+        resetEvent:Fire(crate)
+        return currentHealth
+end
+
+applyDamageEvent.Event:Connect(function(amount, source)
+        applyDamage(amount, source)
+end)
+
+takeDamageFn.OnInvoke = function(amount, source)
+        return applyDamage(amount, source)
+end
+
+resetFn.OnInvoke = function()
+        return resetCrate()
+end
+
+resetEvent.Event:Connect(function()
+        -- Designers can listen and respawn props or chain logic here
+end)
+
+if CONFIG.ENABLE_TOUCH_DAMAGE then
+        primary.Touched:Connect(function(hit)
+                local now = os.clock()
+                if now - lastTouchTime < CONFIG.DAMAGE_COOLDOWN then
+                        return
+                end
+                lastTouchTime = now
+                applyDamage(CONFIG.DAMAGE_PER_HIT, hit)
+        end)
+end
+
+crate:SetAttribute("MaxHealth", CONFIG.MAX_HEALTH)
+crate:SetAttribute("Health", currentHealth)
+updateVisuals(currentHealth) -- Step 04 addition: start with the correct texture/mesh stage

--- a/video6/use-cases.md
+++ b/video6/use-cases.md
@@ -1,0 +1,43 @@
+# Real-world ideas for Destructible Crates
+
+You’ve got a crate that bruises, breaks, and pays out. Drop it into your experience.
+
+---
+
+## 1) Loot Shower
+- Use `steps/01-damage-ready-crate.lua`
+- Tag crates with `CollectionService:AddTag(crate, "DailyCrate")`
+- Randomize `CONFIG.REWARD_TEMPLATE` (coins, health, ammo) when the crate resets
+
+Tip: Use `CrateDestroyed` to update a streak UI or battle pass quest.
+
+---
+
+## 2) Shortcut Gate
+- Use `steps/02-add-wear-textures.lua`
+- Place cracked crates blocking a side tunnel
+- On break, lower collision so players dash through; optionally trigger a door animation
+
+Tip: Swap to a low-profile mesh stage so players can visually read the new path.
+
+---
+
+## 3) Wave Defense Objective
+- Use `steps/03-swap-damaged-meshes.lua`
+- Spawn crates around an objective; enemies smash them to weaken defenses
+- Broadcast `CrateDamaged` to defenders so they know which crate needs repairs
+
+Tip: Let players patch up crates by calling `script.Reset:Invoke()` when they spend resources.
+
+---
+
+## 4) Environmental Storytelling
+- Keep `USE_TEXTURE_SWAPS = true`, disable mesh swaps
+- Drop damaged crates in raid aftermath scenes to show long-term wear
+- Flip `RESET_MODE` to `Regen` so they heal between sessions
+
+Tip: Vary texture stage thresholds per crate so the same damage looks different across the map.
+
+---
+
+Smash, reward, repeat. Mix mesh + texture swaps to match how dramatic (or performant) you need the scene to be.

--- a/video6/wiki.md
+++ b/video6/wiki.md
@@ -1,0 +1,33 @@
+# Key APIs for Destructible Crates
+
+What you’ll touch while building texture + mesh damage with rewards.
+
+## Services
+- `TweenService` — punch or wobble the crate when hits land
+- `Debris` — auto-clean reward clones, FX, or temporary parts
+- `CollectionService` (optional) — tag destructible props for mass updates or quests
+
+## Objects
+- `MeshPart` — lets you swap `MeshId`, `TextureID`, and `CollisionFidelity`
+- `SurfaceAppearance` — modern PBR texture container; clone/swaps per damage stage
+- `BindableEvent` / `BindableFunction` — lightweight messaging between this script and designers’ systems
+- `ParticleEmitter` / `Sound` — optional reward FX triggered on destruction
+- `Attachment` — anchor particle emitters or sound sources without extra parts
+
+## Enums
+- `Enum.CollisionFidelity` — pick collision detail level per mesh variant
+- `Enum.EasingStyle` / `Enum.EasingDirection` — drive wobble tweens for hit feedback
+
+## Docs
+- MeshPart: https://create.roblox.com/docs/reference/engine/classes/MeshPart
+- SurfaceAppearance: https://create.roblox.com/docs/reference/engine/classes/SurfaceAppearance
+- TweenService: https://create.roblox.com/docs/reference/engine/classes/TweenService
+- Debris: https://create.roblox.com/docs/reference/engine/classes/Debris
+- BindableEvent: https://create.roblox.com/docs/reference/engine/classes/BindableEvent
+- ParticleEmitter: https://create.roblox.com/docs/reference/engine/classes/ParticleEmitter
+
+## Tips
+- Keep mesh variants aligned: identical pivot and size prevents physics pops.
+- Group texture maps in a Folder under the script so stages can clone cleanly.
+- Drive designer UI with the `CrateDamaged` event — broadcast health updates to HUDs.
+- Combine `CollectionService:GetTagged("Destructible")` with `CrateDestroyed` to track break goals.


### PR DESCRIPTION
## Summary
- update the destructible crate use cases so each scenario references the matching step script in order

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ce6a19fed48332a93f37eed0ea5e85